### PR TITLE
Add GitHub repo link to ReadTheDocs pages

### DIFF
--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -62,3 +62,11 @@ html_theme_options = {
     'logo_only': True,
     'display_version': False
 }
+
+html_context = {
+    'display_github': True,
+    'github_user': 'Neural-Systems-at-UIO',
+    'github_repo': 'QuickNII',
+    'github_version': 'master',
+    'conf_py_path': '/Docs/',
+}


### PR DESCRIPTION
## Summary
- Enables `sphinx_rtd_theme`'s built-in GitHub integration via `html_context` in `Docs/conf.py`
- Adds a "View on GitHub" / "Edit on GitHub" link to the top-right of every documentation page, pointing to `https://github.com/Neural-Systems-at-UIO/QuickNII`

## Motivation
I found it difficult to navigate to the GitHub repository from the ReadTheDocs site — there was no visible link from the docs back to the source. This change surfaces the repo on every page so contributors and users can jump straight to the code (or propose edits to the docs themselves).

## Test plan
- [x] Build docs locally with `sphinx-build -b html Docs Docs/_build/html` — build succeeds
- [x] Verify the rendered HTML contains a link to `github.com/Neural-Systems-at-UIO/QuickNII/blob/master/Docs/<page>.rst`
- [ ] Confirm the link renders correctly on the ReadTheDocs build preview after this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)